### PR TITLE
[java] typespec-java 0.15.2 and flavor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -350,9 +350,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-java": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-java/-/typespec-java-0.15.0.tgz",
-      "integrity": "sha512-zbwpgUfSZGOEsBwocpBxebhMhW+H3Wy+A0s1MxuvW5mclEKiKdS0vU3zbRMom3OA8XfqvxJF77uQ3oWgnmSZKA==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-java/-/typespec-java-0.15.1.tgz",
+      "integrity": "sha512-Gg7JPR2DCVqd3jgjpleWLtpQvjKjTYTUIWW2ZsugYqQdtQzz4RTiS1+aaqsTRHk/kv46igwhZl9uq3kfq2xDzQ==",
       "dependencies": {
         "@autorest/codemodel": "~4.20.0",
         "js-yaml": "~4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -350,9 +350,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-java": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-java/-/typespec-java-0.14.1.tgz",
-      "integrity": "sha512-FGQV12Ck17mfzTgzrz0gpSYt8NAM9gxYLlWcS3vZpokCGB81VG1VKN6u80ui2HfVKZJldxa8MkwqUvv9zml4Yw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-java/-/typespec-java-0.15.0.tgz",
+      "integrity": "sha512-zbwpgUfSZGOEsBwocpBxebhMhW+H3Wy+A0s1MxuvW5mclEKiKdS0vU3zbRMom3OA8XfqvxJF77uQ3oWgnmSZKA==",
       "dependencies": {
         "@autorest/codemodel": "~4.20.0",
         "js-yaml": "~4.1.0",
@@ -1004,9 +1004,9 @@
       }
     },
     "node_modules/@scalar/fastify-api-reference": {
-      "version": "1.17.15",
-      "resolved": "https://registry.npmjs.org/@scalar/fastify-api-reference/-/fastify-api-reference-1.17.15.tgz",
-      "integrity": "sha512-Q5hVD1e4VOFMeI+h0neEsd83jDfKT/jEr8Ti14PghHbS0y3BpBvDxd9Na8Gte+CcUMk8QJeyUceyj4Ezcr4lfA==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/@scalar/fastify-api-reference/-/fastify-api-reference-1.18.2.tgz",
+      "integrity": "sha512-Xs3CToSnLRvgVxi+jeG1eN0o9ExhFDnbPCn7fyUmd0oPKc+o8tkRR/XJyR6+JullY7E7hwhQPvJImxCy4yk6Jg==",
       "engines": {
         "node": ">=18"
       },
@@ -1195,9 +1195,9 @@
       }
     },
     "node_modules/@typespec/json-schema": {
-      "version": "0.55.0-dev.1",
-      "resolved": "https://registry.npmjs.org/@typespec/json-schema/-/json-schema-0.55.0-dev.1.tgz",
-      "integrity": "sha512-Lw/zKrOghtWq4h4Ed26mdfZIr5obugI7+1lcFYa4YNUB/4zPWItB+NamOrgxKPI0pM4X6MsVAdyT7nYH+0FHOw==",
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@typespec/json-schema/-/json-schema-0.54.0.tgz",
+      "integrity": "sha512-5DZ9xHShUmtWsO3ZETA4EISJPnKKSYaqz2YDRWL/ck5PunJGKOMK1f4kFfj6tFGQDHJwi3FJ7QOD1ZJmpA3EPQ==",
       "dependencies": {
         "yaml": "~2.3.4"
       },
@@ -1205,7 +1205,7 @@
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "~0.54.0 || >=0.55.0-dev <0.55.0"
+        "@typespec/compiler": "~0.54.0"
       }
     },
     "node_modules/@typespec/json-schema/node_modules/yaml": {
@@ -2196,9 +2196,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.697",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.697.tgz",
-      "integrity": "sha512-iPS+iUNUrqTkPRFjMYv1FGXIUYhj2K4rc/93nrDsDtQGMUqyRouCq/xABOSOljKbriEiwg0bEQHGaeD4OaU56g==",
+      "version": "1.4.698",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.698.tgz",
+      "integrity": "sha512-f9iZD1t3CLy1AS6vzM5EKGa6p9pRcOeEFXRFbaG2Ta+Oe7MkfRQ3fsvPYidzHe1h4i0JvIvpcY55C+B6BZNGtQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -350,9 +350,9 @@
       }
     },
     "node_modules/@azure-tools/typespec-java": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-java/-/typespec-java-0.15.1.tgz",
-      "integrity": "sha512-Gg7JPR2DCVqd3jgjpleWLtpQvjKjTYTUIWW2ZsugYqQdtQzz4RTiS1+aaqsTRHk/kv46igwhZl9uq3kfq2xDzQ==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-java/-/typespec-java-0.15.2.tgz",
+      "integrity": "sha512-xS8wd6v6j+EVGDeWvghIHpZwgxWgF3Z8qe0lv4F05rJ8GCpN0qfGoep4l7QIQz6o91qKPS+365vfhm1zWNIMUQ==",
       "dependencies": {
         "@autorest/codemodel": "~4.20.0",
         "js-yaml": "~4.1.0",

--- a/tspconfig.yaml
+++ b/tspconfig.yaml
@@ -14,7 +14,7 @@ options:
     emitter-output-dir: "{output-dir}/java"
     package-dir: "brian-fun-service"
     namespace: "com.brian.fun.service"
-    branded: false
+    flavor: generic
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{output-dir}/typescript"
     title: "Todo Application"


### PR DESCRIPTION
We may want to add in readme that JRE 11 or above is required for Java emitter
https://github.com/bterlson/typespec-todo/blob/9ab0ada81ad1208091e3afed13ced85b43110a54/readme.md?plain=1#L23